### PR TITLE
인증기능 구현

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "@heroicons/react": "^2.2.0",
     "@tailwindcss/vite": "^4.1.11",
     "@tanstack/react-query": "^5.82.0",
-    "@toss/ky": "^1.2.1",
+    "ky": "^1.8.2",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-router-dom": "^7.6.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,9 +17,9 @@ importers:
       '@tanstack/react-query':
         specifier: ^5.82.0
         version: 5.82.0(react@19.1.0)
-      '@toss/ky':
-        specifier: ^1.2.1
-        version: 1.2.1
+      ky:
+        specifier: ^1.8.2
+        version: 1.8.2
       react:
         specifier: ^19.1.0
         version: 19.1.0
@@ -672,9 +672,6 @@ packages:
     peerDependencies:
       react: ^18 || ^19
 
-  '@toss/ky@1.2.1':
-    resolution: {integrity: sha512-72qJyUVyyNC7d4EOKVyjPQH3UH3GnVSAo3mM+3vqGVTgh84vPPW3KPFvrV/DZe33dHMygCUsmIhnP9G5T5n9AQ==}
-
   '@types/cookie@0.6.0':
     resolution: {integrity: sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==}
 
@@ -1082,6 +1079,10 @@ packages:
 
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
+
+  ky@1.8.2:
+    resolution: {integrity: sha512-XybQJ3d4Ea1kI27DoelE5ZCT3bSJlibYTtQuMsyzKox3TMyayw1asgQdl54WroAm+fIA3ZCr8zXW2RpR7qWVpA==}
+    engines: {node: '>=18'}
 
   levn@0.4.1:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
@@ -1959,8 +1960,6 @@ snapshots:
       '@tanstack/query-core': 5.82.0
       react: 19.1.0
 
-  '@toss/ky@1.2.1': {}
-
   '@types/cookie@0.6.0': {}
 
   '@types/estree@1.0.8': {}
@@ -2394,6 +2393,8 @@ snapshots:
   keyv@4.5.4:
     dependencies:
       json-buffer: 3.0.1
+
+  ky@1.8.2: {}
 
   levn@0.4.1:
     dependencies:

--- a/src/app/RequireAuth.tsx
+++ b/src/app/RequireAuth.tsx
@@ -11,5 +11,5 @@ export default function RequireAuth() {
     return <Navigate to="/login" replace state={{ from: loc }} />;
   }
 
-  return <Outlet />;
+  return <Outlet context={user} />;
 }

--- a/src/app/RequireAuth.tsx
+++ b/src/app/RequireAuth.tsx
@@ -1,25 +1,15 @@
 // app/guards/RequireAuth.tsx
-import { userQueries } from '@/entities/user';
 import { useSuspenseQuery } from '@tanstack/react-query';
 import { Navigate, Outlet, useLocation } from 'react-router-dom';
+import { userQueries } from '@/entities/user';
 
-type RequireAuthProps = {
-  children?: React.ReactNode;
-  redirectTo?: string;
-};
-
-export default function RequireAuth({
-  children,
-  redirectTo = '/login',
-}: RequireAuthProps) {
+export default function RequireAuth() {
   const loc = useLocation();
   const { data: user } = useSuspenseQuery(userQueries.me());
 
   if (!user) {
-    alert('로그인 후 이용해주세요.');
-    return <Navigate to={redirectTo} replace state={{ from: loc }} />;
+    return <Navigate to="/login" replace state={{ from: loc }} />;
   }
 
-  // children이 있으면 그대로 렌더, 없으면 라우트 레이아웃(Outlet)로 동작
-  return children ? <>{children}</> : <Outlet />;
+  return <Outlet />;
 }

--- a/src/app/RequireAuth.tsx
+++ b/src/app/RequireAuth.tsx
@@ -6,10 +6,9 @@ import { userQueries } from '@/entities/user';
 export default function RequireAuth() {
   const loc = useLocation();
   const { data: user } = useSuspenseQuery(userQueries.me());
-
-  if (!user) {
+  if (!user.data) {
     return <Navigate to="/login" replace state={{ from: loc }} />;
   }
 
-  return <Outlet context={user} />;
+  return <Outlet context={user.data} />;
 }

--- a/src/app/RequireAuth.tsx
+++ b/src/app/RequireAuth.tsx
@@ -1,0 +1,25 @@
+// app/guards/RequireAuth.tsx
+import { userQueries } from '@/entities/user';
+import { useSuspenseQuery } from '@tanstack/react-query';
+import { Navigate, Outlet, useLocation } from 'react-router-dom';
+
+type RequireAuthProps = {
+  children?: React.ReactNode;
+  redirectTo?: string;
+};
+
+export default function RequireAuth({
+  children,
+  redirectTo = '/login',
+}: RequireAuthProps) {
+  const loc = useLocation();
+  const { data: user } = useSuspenseQuery(userQueries.me());
+
+  if (!user) {
+    alert('로그인 후 이용해주세요.');
+    return <Navigate to={redirectTo} replace state={{ from: loc }} />;
+  }
+
+  // children이 있으면 그대로 렌더, 없으면 라우트 레이아웃(Outlet)로 동작
+  return children ? <>{children}</> : <Outlet />;
+}

--- a/src/app/Router.tsx
+++ b/src/app/Router.tsx
@@ -1,4 +1,7 @@
+import RequireAuth from '@/app/RequireAuth';
 import { LectureDetail, LoginPage, RegisterPage } from '@/pages';
+import { LoadingSpinner } from '@/shared';
+import { Suspense } from 'react';
 import { BrowserRouter, Route, Routes } from 'react-router-dom';
 
 export default function Router() {
@@ -6,9 +9,15 @@ export default function Router() {
     <BrowserRouter>
       <Routes>
         <Route path="/login" element={<LoginPage />} />
-        <Route path="/register" element={<RegisterPage />} />
-        <Route path="/lecture/:id" element={<LectureDetail />} />
       </Routes>
+      <Suspense fallback={<LoadingSpinner />}>
+        <RequireAuth>
+          <Routes>
+            <Route path="/register" element={<RegisterPage />} />
+            <Route path="/lecture/:id" element={<LectureDetail />} />
+          </Routes>
+        </RequireAuth>
+      </Suspense>
     </BrowserRouter>
   );
 }

--- a/src/app/Router.tsx
+++ b/src/app/Router.tsx
@@ -9,15 +9,17 @@ export default function Router() {
     <BrowserRouter>
       <Routes>
         <Route path="/login" element={<LoginPage />} />
+        <Route path="/register" element={<RegisterPage />} />
+        <Route
+          element={
+            <Suspense fallback={<LoadingSpinner />}>
+              <RequireAuth />
+            </Suspense>
+          }
+        >
+          <Route path="/lecture/:id" element={<LectureDetail />} />
+        </Route>
       </Routes>
-      <Suspense fallback={<LoadingSpinner />}>
-        <RequireAuth>
-          <Routes>
-            <Route path="/register" element={<RegisterPage />} />
-            <Route path="/lecture/:id" element={<LectureDetail />} />
-          </Routes>
-        </RequireAuth>
-      </Suspense>
     </BrowserRouter>
   );
 }

--- a/src/app/TQProvider.tsx
+++ b/src/app/TQProvider.tsx
@@ -1,26 +1,28 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
-
-const queryClient = new QueryClient({
-  defaultOptions: {
-    queries: {
-      refetchOnWindowFocus: false,
-      retry: false,
-      staleTime: 1000 * 60 * 5,
-      gcTime: 1000 * 60 * 3,
-    },
-
-    mutations: {
-      retry: false,
-    },
-  },
-});
+import { useState } from 'react';
 
 export default function TQProvider({
   children,
 }: {
   children: React.ReactNode;
 }) {
+  const [queryClient] = useState(
+    new QueryClient({
+      defaultOptions: {
+        queries: {
+          refetchOnWindowFocus: false,
+          retry: false,
+          staleTime: 1000 * 60 * 5,
+          gcTime: 1000 * 60 * 3,
+        },
+
+        mutations: {
+          retry: false,
+        },
+      },
+    })
+  );
   return (
     <QueryClientProvider client={queryClient}>
       <ReactQueryDevtools initialIsOpen={false} />

--- a/src/app/index.ts
+++ b/src/app/index.ts
@@ -1,0 +1,3 @@
+export { default as RequireAuth } from './RequireAuth';
+export { default as Router } from './Router';
+export { default as TQProvider } from './TQProvider';

--- a/src/entities/user/apis/getUser.ts
+++ b/src/entities/user/apis/getUser.ts
@@ -1,4 +1,4 @@
 import type { User } from '@/entities/user';
 import ky from 'ky';
 
-export const getUser = (uid: string) => ky.get<User>(`/user/${uid}`).json();
+export const getUser = () => ky.get<User>('/user').json();

--- a/src/entities/user/apis/getUser.ts
+++ b/src/entities/user/apis/getUser.ts
@@ -1,0 +1,4 @@
+import type { User } from '@/entities/user';
+import ky from 'ky';
+
+export const getUser = (uid: string) => ky.get<User>(`/user/${uid}`).json();

--- a/src/entities/user/apis/getUser.ts
+++ b/src/entities/user/apis/getUser.ts
@@ -1,4 +1,4 @@
 import type { User } from '@/entities/user';
 import { api } from '@/shared';
 
-export const getUser = () => api.get<User>('user').json();
+export const getUser = () => api.get<{ data: User }>('user').json();

--- a/src/entities/user/apis/getUser.ts
+++ b/src/entities/user/apis/getUser.ts
@@ -1,4 +1,4 @@
 import type { User } from '@/entities/user';
-import ky from 'ky';
+import { api } from '@/shared';
 
-export const getUser = () => ky.get<User>('/user').json();
+export const getUser = () => api.get<User>('user').json();

--- a/src/entities/user/apis/index.ts
+++ b/src/entities/user/apis/index.ts
@@ -1,0 +1,2 @@
+export * from './login';
+export * from './getUser';

--- a/src/entities/user/apis/login.ts
+++ b/src/entities/user/apis/login.ts
@@ -1,7 +1,7 @@
 import type { User } from '@/entities/user';
 import ky from 'ky';
 
-const login = () =>
+export const login = () =>
   ky
     .post<User>('/login', { json: { username: 'john', password: 'secret' } })
     .json();

--- a/src/entities/user/apis/login.ts
+++ b/src/entities/user/apis/login.ts
@@ -1,0 +1,7 @@
+import type { User } from '@/entities/user';
+import ky from 'ky';
+
+const login = () =>
+  ky
+    .post<User>('/login', { json: { username: 'john', password: 'secret' } })
+    .json();

--- a/src/entities/user/apis/login.ts
+++ b/src/entities/user/apis/login.ts
@@ -1,5 +1,5 @@
 import type { LoginRequest, User } from '@/entities/user';
-import ky from 'ky';
+import { api } from '@/shared';
 
 export const login = ({ id, password }: LoginRequest) =>
-  ky.post<User>('/login', { json: { id, password } }).json();
+  api.post<User>('/login', { json: { id, password } }).json();

--- a/src/entities/user/apis/login.ts
+++ b/src/entities/user/apis/login.ts
@@ -1,9 +1,5 @@
-import type { User } from '@/entities/user';
+import type { LoginRequest, User } from '@/entities/user';
 import ky from 'ky';
 
-interface LoginRequest {
-  id: string;
-  password: string;
-}
 export const login = ({ id, password }: LoginRequest) =>
   ky.post<User>('/login', { json: { id, password } }).json();

--- a/src/entities/user/apis/login.ts
+++ b/src/entities/user/apis/login.ts
@@ -1,7 +1,9 @@
 import type { User } from '@/entities/user';
 import ky from 'ky';
 
-export const login = () =>
-  ky
-    .post<User>('/login', { json: { username: 'john', password: 'secret' } })
-    .json();
+interface LoginRequest {
+  id: string;
+  password: string;
+}
+export const login = ({ id, password }: LoginRequest) =>
+  ky.post<User>('/login', { json: { id, password } }).json();

--- a/src/entities/user/apis/login.ts
+++ b/src/entities/user/apis/login.ts
@@ -2,4 +2,4 @@ import type { LoginRequest, User } from '@/entities/user';
 import { api } from '@/shared';
 
 export const login = ({ id, password }: LoginRequest) =>
-  api.post<User>('/login', { json: { id, password } }).json();
+  api.post<User>('login', { json: { id, password } }).json();

--- a/src/entities/user/hooks/useAuth.tsx
+++ b/src/entities/user/hooks/useAuth.tsx
@@ -1,0 +1,9 @@
+import type { User } from '@/entities/user/types';
+import { useOutletContext } from 'react-router-dom';
+
+export const useAuth = () => {
+  const user = useOutletContext<User>();
+  if (!user)
+    throw new Error('useAuth는 RequireAuth 하위에서만 사용해야 합니다.');
+  return user;
+};

--- a/src/entities/user/index.ts
+++ b/src/entities/user/index.ts
@@ -1,0 +1,2 @@
+export * from './types';
+export * from './apis';

--- a/src/entities/user/index.ts
+++ b/src/entities/user/index.ts
@@ -1,2 +1,3 @@
 export * from './types';
 export * from './apis';
+export * from './userQueries';

--- a/src/entities/user/index.ts
+++ b/src/entities/user/index.ts
@@ -1,3 +1,4 @@
 export * from './types';
 export * from './apis';
 export * from './userQueries';
+export * from './ui';

--- a/src/entities/user/types/index.ts
+++ b/src/entities/user/types/index.ts
@@ -1,0 +1,1 @@
+export * from './user';

--- a/src/entities/user/types/index.ts
+++ b/src/entities/user/types/index.ts
@@ -1,1 +1,2 @@
 export * from './user';
+export * from './request';

--- a/src/entities/user/types/request.ts
+++ b/src/entities/user/types/request.ts
@@ -1,0 +1,4 @@
+export interface LoginRequest {
+  id: string;
+  password: string;
+}

--- a/src/entities/user/types/user.ts
+++ b/src/entities/user/types/user.ts
@@ -1,0 +1,5 @@
+export interface User {
+  id: string;
+  nickname: string;
+  password: string;
+}

--- a/src/entities/user/userQueries.ts
+++ b/src/entities/user/userQueries.ts
@@ -1,0 +1,11 @@
+import { queryOptions } from '@tanstack/react-query';
+import { getUser } from '@entities/user';
+
+export const userQueries = {
+  all: () => ['user'] as const,
+  detail: (uid: string) =>
+    queryOptions({
+      queryKey: [...userQueries.all(), uid],
+      queryFn: () => getUser(uid),
+    }),
+};

--- a/src/entities/user/userQueries.ts
+++ b/src/entities/user/userQueries.ts
@@ -8,5 +8,8 @@ export const userQueries = {
       queryFn: () => getUser(),
       gcTime: Infinity,
       staleTime: Infinity,
+      refetchOnMount: false,
+      refetchOnWindowFocus: false,
+      refetchOnReconnect: false,
     }),
 };

--- a/src/entities/user/userQueries.ts
+++ b/src/entities/user/userQueries.ts
@@ -2,10 +2,11 @@ import { queryOptions } from '@tanstack/react-query';
 import { getUser } from '@entities/user';
 
 export const userQueries = {
-  all: () => ['user'] as const,
-  detail: (uid: string) =>
+  me: () =>
     queryOptions({
-      queryKey: [...userQueries.all(), uid],
-      queryFn: () => getUser(uid),
+      queryKey: ['me'],
+      queryFn: () => getUser(),
+      gcTime: Infinity,
+      staleTime: Infinity,
     }),
 };

--- a/src/features/login/index.ts
+++ b/src/features/login/index.ts
@@ -1,1 +1,2 @@
 export * from './ui';
+export * from './model';

--- a/src/features/login/model/index.ts
+++ b/src/features/login/model/index.ts
@@ -1,0 +1,1 @@
+export * from './useLogin';

--- a/src/features/login/model/useLogin.ts
+++ b/src/features/login/model/useLogin.ts
@@ -1,0 +1,7 @@
+import { login } from '@/entities/user';
+import { useMutation } from '@tanstack/react-query';
+
+export const useLogin = () => {
+  const mutation = useMutation({ mutationFn: login });
+  return mutation;
+};

--- a/src/features/login/model/useLogin.ts
+++ b/src/features/login/model/useLogin.ts
@@ -1,7 +1,24 @@
-import { login } from '@/entities/user';
+import { login, type LoginRequest } from '@/entities/user';
 import { useMutation } from '@tanstack/react-query';
+import { useNavigate } from 'react-router-dom';
 
 export const useLogin = () => {
+  const navigate = useNavigate();
   const mutation = useMutation({ mutationFn: login });
-  return mutation;
+
+  const handleMutate = ({ id, password }: LoginRequest) => {
+    mutation.mutate(
+      { id, password },
+      {
+        onSuccess: (data) => {
+          navigate('/');
+          console.log('Login successful:', data);
+        },
+        onError: (error) => {
+          console.error('Login failed:', error);
+        },
+      }
+    );
+  };
+  return { ...mutation, handleMutate };
 };

--- a/src/features/login/ui/LoginButton.tsx
+++ b/src/features/login/ui/LoginButton.tsx
@@ -5,6 +5,7 @@ interface LoginButtonProps {
 export default function LoginButton({ onClick }: LoginButtonProps) {
   return (
     <button
+      type="button"
       onClick={onClick}
       className="shadow-2xl w-full h-[55px] bg-gradient-to-r from-[#D2886F] to-[#D4B896] text-white font-bold py-2 px-4 rounded-[10px] cursor-pointer"
     >

--- a/src/features/login/ui/LoginButton.tsx
+++ b/src/features/login/ui/LoginButton.tsx
@@ -1,11 +1,11 @@
-export default function LoginButton() {
-  const handleOnClick = () => {
-    console.log('로그인 버튼 클릭');
-  };
+interface LoginButtonProps {
+  onClick: (e: React.MouseEvent<HTMLButtonElement>) => void;
+}
 
+export default function LoginButton({ onClick }: LoginButtonProps) {
   return (
     <button
-      onClick={handleOnClick}
+      onClick={onClick}
       className="shadow-2xl w-full h-[55px] bg-gradient-to-r from-[#D2886F] to-[#D4B896] text-white font-bold py-2 px-4 rounded-[10px] cursor-pointer"
     >
       로그인

--- a/src/features/login/ui/LoginForm.tsx
+++ b/src/features/login/ui/LoginForm.tsx
@@ -10,13 +10,13 @@ import {
 import { useState } from 'react';
 
 export default function LoginForm() {
-  const { mutate } = useLogin();
+  const { handleMutate } = useLogin();
   const [id, setId] = useState('');
   const [password, setPassword] = useState('');
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
-    mutate({ id, password });
+    handleMutate({ id, password });
   };
 
   return (

--- a/src/features/login/ui/LoginForm.tsx
+++ b/src/features/login/ui/LoginForm.tsx
@@ -3,21 +3,35 @@ import {
   AutoLoginToggle,
   FindPasswordButton,
   GoToRegisterLink,
-  IdInput,
   PasswordInput,
+  IdInput,
+  useLogin,
 } from '@features/login';
+import { useState } from 'react';
 
 export default function LoginForm() {
+  const { mutate } = useLogin();
+  const [id, setId] = useState('');
+  const [password, setPassword] = useState('');
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    mutate({ id, password });
+  };
+
   return (
     <form className="flex flex-col w-full">
-      <IdInput onChange={() => {}} value="" />
+      <IdInput onChange={(e) => setId(e.target.value)} value={id} />
       <div className="mt-9" />
-      <PasswordInput onChange={() => {}} value="" />
+      <PasswordInput
+        onChange={(e) => setPassword(e.target.value)}
+        value={password}
+      />
       <div className="flex justify-between items-center mt-8 mb-18">
         <AutoLoginToggle />
         <FindPasswordButton />
       </div>
-      <LoginButton />
+      <LoginButton onClick={handleSubmit} />
       <div className="mt-5.5 flex justify-center">
         <GoToRegisterLink />
       </div>

--- a/src/features/login/ui/index.ts
+++ b/src/features/login/ui/index.ts
@@ -3,5 +3,5 @@ export { default as LoginForm } from './LoginForm';
 export { default as AutoLoginToggle } from './AutoLoginToggle';
 export { default as FindPasswordButton } from './FindPasswordButton';
 export { default as GoToRegisterLink } from './GoToRegisterLink';
-export { default as IdInput } from './IdInput';
 export { default as PasswordInput } from './PasswordInput';
+export { default as IdInput } from './IdInput';

--- a/src/mocks/auth.mock.ts
+++ b/src/mocks/auth.mock.ts
@@ -12,7 +12,7 @@ export const authHandlers = [
           { message: 'Login successful' },
           {
             headers: {
-              'set-cookie': 'sessionId=abc123; Path=/; SameSite=Strict',
+              'set-cookie': 'sessionId=abc123; Path=/api;',
             },
           }
         );
@@ -29,12 +29,17 @@ export const authHandlers = [
   http.get('/api/user', ({ cookies }) => {
     if (cookies.sessionId === 'abc123') {
       return HttpResponse.json({
-        id: 'abc-123',
-        firstName: 'John',
-        lastName: 'Maverick',
+        data: {
+          id: 'abc-123',
+          firstName: 'John',
+          lastName: 'Maverick',
+        },
       });
     }
 
-    return HttpResponse.json({ message: 'Unauthorized' }, { status: 401 });
+    return HttpResponse.json(
+      { data: null, message: 'Unauthorized' },
+      { status: 200 }
+    );
   }),
 ];

--- a/src/mocks/auth.mock.ts
+++ b/src/mocks/auth.mock.ts
@@ -12,8 +12,7 @@ export const authHandlers = [
           { message: 'Login successful' },
           {
             headers: {
-              'Set-Cookie':
-                'sessionId=abc123; Path=/; HttpOnly; Secure; SameSite=Strict',
+              'set-cookie': 'sessionId=abc123; Path=/; SameSite=Strict',
             },
           }
         );

--- a/src/mocks/auth.mock.ts
+++ b/src/mocks/auth.mock.ts
@@ -2,12 +2,12 @@ import { http, HttpResponse } from 'msw';
 
 // 로그인 핸들러
 export const authHandlers = [
-  http.post<object, { username: string; password: string }>(
+  http.post<object, { id: string; password: string }>(
     '/login',
     async ({ request }) => {
-      const { username, password } = await request.json();
+      const { id, password } = await request.json();
 
-      if (username === 'john' && password === 'secret') {
+      if (id === 'john' && password === 'secret') {
         return HttpResponse.json(
           { message: 'Login successful' },
           {

--- a/src/mocks/auth.mock.ts
+++ b/src/mocks/auth.mock.ts
@@ -3,7 +3,7 @@ import { http, HttpResponse } from 'msw';
 // 로그인 핸들러
 export const authHandlers = [
   http.post<object, { id: string; password: string }>(
-    '/login',
+    '/api/login',
     async ({ request }) => {
       const { id, password } = await request.json();
 
@@ -26,7 +26,7 @@ export const authHandlers = [
   ),
 
   // 로그인된 유저 정보 요청
-  http.get('/user', ({ cookies }) => {
+  http.get('/api/user', ({ cookies }) => {
     if (cookies.sessionId === 'abc123') {
       return HttpResponse.json({
         id: 'abc-123',

--- a/src/mocks/auth.mock.ts
+++ b/src/mocks/auth.mock.ts
@@ -1,0 +1,41 @@
+import { http, HttpResponse } from 'msw';
+
+// 로그인 핸들러
+export const authHandlers = [
+  http.post<object, { username: string; password: string }>(
+    '/login',
+    async ({ request }) => {
+      const { username, password } = await request.json();
+
+      if (username === 'john' && password === 'secret') {
+        return HttpResponse.json(
+          { message: 'Login successful' },
+          {
+            headers: {
+              'Set-Cookie':
+                'sessionId=abc123; Path=/; HttpOnly; Secure; SameSite=Strict',
+            },
+          }
+        );
+      }
+
+      return HttpResponse.json(
+        { message: 'Invalid credentials' },
+        { status: 401 }
+      );
+    }
+  ),
+
+  // 로그인된 유저 정보 요청
+  http.get('/user', ({ cookies }) => {
+    if (cookies.sessionId === 'abc123') {
+      return HttpResponse.json({
+        id: 'abc-123',
+        firstName: 'John',
+        lastName: 'Maverick',
+      });
+    }
+
+    return HttpResponse.json({ message: 'Unauthorized' }, { status: 401 });
+  }),
+];

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -1,11 +1,3 @@
-import { http, HttpResponse } from 'msw';
+import { authHandlers } from '@/mocks/auth.mock';
 
-export const handlers = [
-  http.get('https://api.example.com/user', () => {
-    return HttpResponse.json({
-      id: 'abc-123',
-      firstName: 'John',
-      lastName: 'Maverick',
-    });
-  }),
-];
+export const handlers = [...authHandlers];

--- a/src/shared/api/index.ts
+++ b/src/shared/api/index.ts
@@ -1,0 +1,1 @@
+export * from './ky';

--- a/src/shared/api/ky.ts
+++ b/src/shared/api/ky.ts
@@ -1,0 +1,9 @@
+// src/shared/api/ky.ts
+import ky from 'ky';
+
+export const api = ky.create({
+  prefixUrl: `${window.location.origin}/api`,
+  credentials: 'include',
+  headers: { 'Content-Type': 'application/json' },
+  retry: { limit: 0 },
+});

--- a/src/shared/index.ts
+++ b/src/shared/index.ts
@@ -1,0 +1,1 @@
+export * from './ui';

--- a/src/shared/index.ts
+++ b/src/shared/index.ts
@@ -1,1 +1,2 @@
 export * from './ui';
+export * from './api';

--- a/src/shared/ui/LoadingSpinner.tsx
+++ b/src/shared/ui/LoadingSpinner.tsx
@@ -1,0 +1,13 @@
+interface LoadingSpinnerProps {
+  className?: string;
+}
+
+export default function LoadingSpinner({
+  className = '',
+}: LoadingSpinnerProps) {
+  return (
+    <div className={className}>
+      <div className="w-6 h-6 border-2 border-blue-500 border-t-transparent rounded-full animate-spin" />
+    </div>
+  );
+}

--- a/src/shared/ui/index.ts
+++ b/src/shared/ui/index.ts
@@ -1,0 +1,1 @@
+export { default as LoadingSpinner } from './LoadingSpinner';


### PR DESCRIPTION
## 🔗 관련 이슈
#13 
<!-- 이 PR과 관련된 이슈 번호를 적어주세요. 예: #123 -->

## 📝작업 내용
로그인 시 특정 라우팅 내부에서 인증을 유지할 수 있도록 구현했습니다.
인증정보는 보안을 위해 쿠키로 구현했고 
리액트 쿼리 캐시를 이용해 재요청 없이 프로바이더 내부에서 인증정보를 가져다 쓸 수 있도록 했습니다.
<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->

## 🔍 변경 사항

- [ ] 변경 사항 1
- [ ] 변경 사항 2
- [ ] 변경 사항 3

## 💬리뷰 요구사항 (선택사항)
