### PR TITLE
과제 제출기능 추가

### DIFF
--- a/src/app/Router.tsx
+++ b/src/app/Router.tsx
@@ -54,7 +54,7 @@ const createRouter = (queryClient: QueryClient) => {
             }),
         },
         {
-          path: '/lecture/:id/assignments/:assignmentsId',
+          path: '/lecture/:id/assignments/:assignmentId',
           element: <Assignment />,
         },
       ],

--- a/src/entities/assignment/apis/createAssignment.ts
+++ b/src/entities/assignment/apis/createAssignment.ts
@@ -1,4 +1,4 @@
-import type { Assignment } from '@/entities/assignment';
+import type { AssignmentFile } from '@/entities/assignment';
 import { api } from '@/shared';
 
 export const createAssignment = async (file: File) => {
@@ -9,6 +9,6 @@ export const createAssignment = async (file: File) => {
         'Content-Type': file.type,
       },
     })
-    .json<{ data: Assignment }>();
+    .json<{ data: AssignmentFile }>();
   return response.data;
 };

--- a/src/entities/assignment/apis/createAssignment.ts
+++ b/src/entities/assignment/apis/createAssignment.ts
@@ -2,13 +2,14 @@ import type { AssignmentFile } from '@/entities/assignment';
 import { api } from '@/shared';
 
 export const createAssignment = async (file: File) => {
+  const formData = new FormData();
+  formData.append('file', file, file.name);
+
   const response = await api
     .post('assignment', {
-      body: file,
-      headers: {
-        'Content-Type': file.type,
-      },
+      body: formData,
     })
     .json<{ data: AssignmentFile }>();
+
   return response.data;
 };

--- a/src/entities/assignment/apis/createAssignment.ts
+++ b/src/entities/assignment/apis/createAssignment.ts
@@ -1,0 +1,14 @@
+import type { Assignment } from '@/entities/assignment';
+import { api } from '@/shared';
+
+export const createAssignment = async (file: File) => {
+  const response = await api
+    .post('assignment', {
+      body: file,
+      headers: {
+        'Content-Type': file.type,
+      },
+    })
+    .json<{ data: Assignment }>();
+  return response.data;
+};

--- a/src/entities/assignment/apis/deleteAssignment.ts
+++ b/src/entities/assignment/apis/deleteAssignment.ts
@@ -1,0 +1,10 @@
+import type { Assignment } from '@/entities/assignment';
+import { api } from '@/shared';
+
+export const deleteAssignment = async (assignmentId: string) => {
+  const response = await api
+    .delete(`assignment/${assignmentId}`)
+    .json<{ data: Assignment }>();
+
+  return response.data;
+};

--- a/src/entities/assignment/apis/deleteAssignment.ts
+++ b/src/entities/assignment/apis/deleteAssignment.ts
@@ -1,10 +1,10 @@
-import type { Assignment } from '@/entities/assignment';
+import type { AssignmentFile } from '@/entities/assignment';
 import { api } from '@/shared';
 
 export const deleteAssignment = async (assignmentId: string) => {
   const response = await api
     .delete(`assignment/${assignmentId}`)
-    .json<{ data: Assignment }>();
+    .json<{ data: AssignmentFile }>();
 
   return response.data;
 };

--- a/src/entities/assignment/apis/getAssignments.ts
+++ b/src/entities/assignment/apis/getAssignments.ts
@@ -4,6 +4,6 @@ import { api } from '@/shared';
 export const getAssignments = async (assignmentId: string) => {
   const response = await api
     .get(`assignment/${assignmentId}`)
-    .json<{ data: AssignmentFile[] | null }>();
+    .json<{ data: AssignmentFile[] | [] }>();
   return response.data;
 };

--- a/src/entities/assignment/apis/getAssignments.ts
+++ b/src/entities/assignment/apis/getAssignments.ts
@@ -1,0 +1,9 @@
+import type { Assignment } from '@/entities/assignment';
+import { api } from '@/shared';
+
+export const getAssignments = async (assignmentId: string) => {
+  const response = await api
+    .get(`assignment/${assignmentId}`)
+    .json<{ data: Assignment[] }>();
+  return response.data;
+};

--- a/src/entities/assignment/apis/getAssignments.ts
+++ b/src/entities/assignment/apis/getAssignments.ts
@@ -1,9 +1,9 @@
-import type { Assignment } from '@/entities/assignment';
+import type { AssignmentFile } from '@/entities/assignment';
 import { api } from '@/shared';
 
 export const getAssignments = async (assignmentId: string) => {
   const response = await api
     .get(`assignment/${assignmentId}`)
-    .json<{ data: Assignment[] }>();
+    .json<{ data: AssignmentFile[] | null }>();
   return response.data;
 };

--- a/src/entities/assignment/apis/index.ts
+++ b/src/entities/assignment/apis/index.ts
@@ -1,0 +1,3 @@
+export * from './createAssignment';
+export * from './deleteAssignment';
+export * from './getAssignments';

--- a/src/entities/assignment/assignmentQueries.ts
+++ b/src/entities/assignment/assignmentQueries.ts
@@ -1,0 +1,10 @@
+import { getAssignments } from '@/entities/assignment';
+import { queryOptions } from '@tanstack/react-query';
+
+export const assignmentQueries = {
+  all: (assignmentId: string) =>
+    queryOptions({
+      queryKey: ['assignments', assignmentId],
+      queryFn: () => getAssignments(assignmentId),
+    }),
+};

--- a/src/entities/assignment/index.ts
+++ b/src/entities/assignment/index.ts
@@ -1,0 +1,2 @@
+export * from './apis';
+export * from './types';

--- a/src/entities/assignment/index.ts
+++ b/src/entities/assignment/index.ts
@@ -1,2 +1,3 @@
 export * from './apis';
 export * from './types';
+export * from './assignmentQueries';

--- a/src/entities/assignment/types/assignment.ts
+++ b/src/entities/assignment/types/assignment.ts
@@ -1,0 +1,6 @@
+export interface Assignment {
+  title: string;
+  fileName: string;
+  fileContent: string;
+  fileSize: number;
+}

--- a/src/entities/assignment/types/assignmentFile.ts
+++ b/src/entities/assignment/types/assignmentFile.ts
@@ -3,4 +3,5 @@ export interface AssignmentFile {
   fileName: string;
   fileContent: string;
   fileSize: number;
+  status?: 'uploading' | 'success' | 'error';
 }

--- a/src/entities/assignment/types/assignmentFile.ts
+++ b/src/entities/assignment/types/assignmentFile.ts
@@ -1,5 +1,5 @@
-export interface Assignment {
-  title: string;
+export interface AssignmentFile {
+  id: string;
   fileName: string;
   fileContent: string;
   fileSize: number;

--- a/src/entities/assignment/types/index.ts
+++ b/src/entities/assignment/types/index.ts
@@ -1,0 +1,1 @@
+export * from './assignment';

--- a/src/entities/assignment/types/index.ts
+++ b/src/entities/assignment/types/index.ts
@@ -1,1 +1,1 @@
-export * from './assignment';
+export * from './assignmentFile';

--- a/src/features/assignment/index.ts
+++ b/src/features/assignment/index.ts
@@ -1,1 +1,2 @@
 export * from './ui';
+export * from './model';

--- a/src/features/assignment/model/index.ts
+++ b/src/features/assignment/model/index.ts
@@ -1,0 +1,1 @@
+export * from './useUploadAssignment';

--- a/src/features/assignment/model/useUploadAssignment.ts
+++ b/src/features/assignment/model/useUploadAssignment.ts
@@ -1,0 +1,56 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import {
+  assignmentQueries,
+  createAssignment,
+  type AssignmentFile,
+} from '@/entities/assignment';
+
+export const useUploadAssignment = (assignmentId: string) => {
+  const queryClient = useQueryClient();
+  const queryKey = assignmentQueries.all(assignmentId).queryKey;
+
+  const { mutateAsync, isPending } = useMutation({
+    mutationFn: createAssignment,
+
+    onMutate: async (newFile: File) => {
+      await queryClient.cancelQueries({ queryKey });
+
+      const previousAssignments =
+        queryClient.getQueryData<AssignmentFile[]>(queryKey);
+
+      queryClient.setQueryData<AssignmentFile[]>(queryKey, oldData => {
+        const optimisticAssignment: AssignmentFile = {
+          id: `temp-${newFile.name}-${Date.now()}`,
+          fileName: newFile.name,
+          fileSize: newFile.size,
+          fileContent: '',
+          status: 'uploading',
+        };
+        return oldData
+          ? [...oldData, optimisticAssignment]
+          : [optimisticAssignment];
+      });
+
+      return { previousAssignments };
+    },
+
+    onError: (_err, _newFile, context) => {
+      if (context?.previousAssignments) {
+        queryClient.setQueryData(queryKey, context.previousAssignments);
+      }
+    },
+
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey });
+    },
+  });
+
+  const handleUpload = async (files: FileList | File[]) => {
+    const filesToUpload = Array.from(files);
+    const uploadPromises = filesToUpload.map(file => mutateAsync(file));
+
+    await Promise.allSettled(uploadPromises);
+  };
+
+  return { handleUpload, isPending };
+};

--- a/src/features/assignment/ui/AddFileButton.tsx
+++ b/src/features/assignment/ui/AddFileButton.tsx
@@ -1,0 +1,41 @@
+// src/components/AddFileButton.tsx
+import { useRef } from 'react';
+
+interface AddFileButtonProps {
+  onFilesSelected: (files: FileList) => void;
+}
+
+export default function AddFileButton({ onFilesSelected }: AddFileButtonProps) {
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const handleButtonClick = () => {
+    fileInputRef.current?.click();
+  };
+
+  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    if (e.target.files) {
+      onFilesSelected(e.target.files);
+      e.target.value = '';
+    }
+  };
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={handleButtonClick}
+        className="justify-center py-2 px-4 text-white border-blue-300 border-b-4 shadow-sky-950 shadow- text-sm font-medium rounded-md  bg-primary-blue
+                            hover:bg-secondary-blue  focus:outline-none hover:border-secondary-blue mb-4 md:mb-0"
+      >
+        파일 추가
+      </button>
+      <input
+        ref={fileInputRef}
+        type="file"
+        multiple
+        className="hidden"
+        onChange={handleFileChange}
+      />
+    </>
+  );
+}

--- a/src/features/assignment/ui/AssignmentContainer.tsx
+++ b/src/features/assignment/ui/AssignmentContainer.tsx
@@ -1,5 +1,5 @@
 import { assignmentQueries } from '@/entities/assignment';
-import { FileSubmitForm, FileList } from '@/features/assignment';
+import { FileSubmitForm, FileList, AddFileButton } from '@/features/assignment';
 import { useSuspenseQuery } from '@tanstack/react-query';
 import { useParams } from 'react-router-dom';
 
@@ -16,6 +16,28 @@ export default function AssignmentContainer() {
         과제 제출
       </h2>
       {data ? <FileList assignmentsFileList={data} /> : <FileSubmitForm />}
+      <div className="flex flex-col md:flex-row items-start md:items-center justify-between">
+        <AddFileButton
+          onFilesSelected={file => {
+            console.log(file);
+          }}
+        />
+        <div className="flex items-center">
+          <label
+            htmlFor="score"
+            className="block text-sm font-medium text-gray-700 mr-2"
+          >
+            점수
+          </label>
+          <input
+            type="text"
+            name="score"
+            id="score"
+            readOnly
+            className="block w-20 rounded-md border-gray-300 shadow-sm sm:text-sm p-2"
+          />
+        </div>
+      </div>
     </section>
   );
 }

--- a/src/features/assignment/ui/AssignmentContainer.tsx
+++ b/src/features/assignment/ui/AssignmentContainer.tsx
@@ -1,11 +1,67 @@
-import { assignmentQueries } from '@/entities/assignment';
+import {
+  assignmentQueries,
+  createAssignment,
+  type AssignmentFile,
+} from '@/entities/assignment';
 import { FileSubmitForm, FileList, AddFileButton } from '@/features/assignment';
-import { useSuspenseQuery } from '@tanstack/react-query';
+import {
+  useMutation,
+  useSuspenseQuery,
+  useQueryClient,
+} from '@tanstack/react-query';
 import { useParams } from 'react-router-dom';
 
 export default function AssignmentContainer() {
   const { assignmentId } = useParams() as { assignmentId: string };
   const { data } = useSuspenseQuery(assignmentQueries.all(assignmentId));
+  const queryClient = useQueryClient();
+
+  const { mutateAsync } = useMutation({
+    mutationFn: createAssignment,
+
+    onMutate: async (newFile: File) => {
+      const queryKey = assignmentQueries.all(assignmentId).queryKey;
+
+      await queryClient.cancelQueries({ queryKey });
+
+      const previousAssignments = queryClient.getQueryData(queryKey);
+
+      queryClient.setQueryData(queryKey, oldData => {
+        const optimisticAssignment: AssignmentFile = {
+          id: `temp-${newFile.name}`,
+          fileName: newFile.name,
+          fileSize: newFile.size,
+          fileContent: '',
+          status: 'uploading',
+        };
+        return oldData
+          ? [...oldData, optimisticAssignment]
+          : [optimisticAssignment];
+      });
+
+      return { previousAssignments };
+    },
+
+    onError: (_err, _newFile, context) => {
+      const queryKey = assignmentQueries.all(assignmentId).queryKey;
+      if (context?.previousAssignments) {
+        queryClient.setQueryData(queryKey, context.previousAssignments);
+      }
+    },
+  });
+
+  const handleUpload = async (files: FileList) => {
+    const uploadPromises = [];
+    for (const file of files) {
+      const assignmentFile = await mutateAsync(file);
+      uploadPromises.push(assignmentFile);
+    }
+
+    await Promise.allSettled(uploadPromises);
+    queryClient.invalidateQueries({
+      queryKey: assignmentQueries.all(assignmentId).queryKey,
+    });
+  };
 
   return (
     <section className="p-6 md:p-8 mb-4" aria-labelledby="submission-heading">
@@ -15,7 +71,11 @@ export default function AssignmentContainer() {
       >
         과제 제출
       </h2>
-      {data ? <FileList assignmentsFileList={data} /> : <FileSubmitForm />}
+      {data.length !== 0 ? (
+        <FileList assignmentsFileList={data} />
+      ) : (
+        <FileSubmitForm handleUpload={handleUpload} />
+      )}
       <div className="flex flex-col md:flex-row items-start md:items-center justify-between">
         <AddFileButton
           onFilesSelected={file => {

--- a/src/features/assignment/ui/AssignmentContainer.tsx
+++ b/src/features/assignment/ui/AssignmentContainer.tsx
@@ -1,67 +1,18 @@
-import {
-  assignmentQueries,
-  createAssignment,
-  type AssignmentFile,
-} from '@/entities/assignment';
+import { assignmentQueries } from '@/entities/assignment';
 import { FileSubmitForm, FileList, AddFileButton } from '@/features/assignment';
-import {
-  useMutation,
-  useSuspenseQuery,
-  useQueryClient,
-} from '@tanstack/react-query';
+import { useUploadAssignment } from '@/features/assignment/model';
+import { useSuspenseQuery } from '@tanstack/react-query';
 import { useParams } from 'react-router-dom';
 
 export default function AssignmentContainer() {
   const { assignmentId } = useParams() as { assignmentId: string };
-  const { data } = useSuspenseQuery(assignmentQueries.all(assignmentId));
-  const queryClient = useQueryClient();
-
-  const { mutateAsync } = useMutation({
-    mutationFn: createAssignment,
-
-    onMutate: async (newFile: File) => {
-      const queryKey = assignmentQueries.all(assignmentId).queryKey;
-
-      await queryClient.cancelQueries({ queryKey });
-
-      const previousAssignments = queryClient.getQueryData(queryKey);
-
-      queryClient.setQueryData(queryKey, oldData => {
-        const optimisticAssignment: AssignmentFile = {
-          id: `temp-${newFile.name}`,
-          fileName: newFile.name,
-          fileSize: newFile.size,
-          fileContent: '',
-          status: 'uploading',
-        };
-        return oldData
-          ? [...oldData, optimisticAssignment]
-          : [optimisticAssignment];
-      });
-
-      return { previousAssignments };
-    },
-
-    onError: (_err, _newFile, context) => {
-      const queryKey = assignmentQueries.all(assignmentId).queryKey;
-      if (context?.previousAssignments) {
-        queryClient.setQueryData(queryKey, context.previousAssignments);
-      }
+  const { data } = useSuspenseQuery({
+    ...assignmentQueries.all(assignmentId),
+    select: list => {
+      return list.map(data => ({ ...data, status: 'success' }));
     },
   });
-
-  const handleUpload = async (files: FileList) => {
-    const uploadPromises = [];
-    for (const file of files) {
-      const assignmentFile = await mutateAsync(file);
-      uploadPromises.push(assignmentFile);
-    }
-
-    await Promise.allSettled(uploadPromises);
-    queryClient.invalidateQueries({
-      queryKey: assignmentQueries.all(assignmentId).queryKey,
-    });
-  };
+  const { handleUpload } = useUploadAssignment(assignmentId);
 
   return (
     <section className="p-6 md:p-8 mb-4" aria-labelledby="submission-heading">
@@ -77,11 +28,7 @@ export default function AssignmentContainer() {
         <FileSubmitForm handleUpload={handleUpload} />
       )}
       <div className="flex flex-col md:flex-row items-start md:items-center justify-between">
-        <AddFileButton
-          onFilesSelected={file => {
-            console.log(file);
-          }}
-        />
+        <AddFileButton onFilesSelected={handleUpload} />
         <div className="flex items-center">
           <label
             htmlFor="score"

--- a/src/features/assignment/ui/AssignmentContainer.tsx
+++ b/src/features/assignment/ui/AssignmentContainer.tsx
@@ -1,0 +1,21 @@
+import { assignmentQueries } from '@/entities/assignment';
+import { FileSubmitForm, FileList } from '@/features/assignment';
+import { useSuspenseQuery } from '@tanstack/react-query';
+import { useParams } from 'react-router-dom';
+
+export default function AssignmentContainer() {
+  const { assignmentId } = useParams() as { assignmentId: string };
+  const { data } = useSuspenseQuery(assignmentQueries.all(assignmentId));
+
+  return (
+    <section className="p-6 md:p-8 mb-4" aria-labelledby="submission-heading">
+      <h2
+        id="submission-heading"
+        className="text-xl font-semibold text-gray-800 mb-6"
+      >
+        과제 제출
+      </h2>
+      {data ? <FileList assignmentsFileList={data} /> : <FileSubmitForm />}
+    </section>
+  );
+}

--- a/src/features/assignment/ui/AssignmentContainer.tsx
+++ b/src/features/assignment/ui/AssignmentContainer.tsx
@@ -9,7 +9,7 @@ export default function AssignmentContainer() {
   const { data } = useSuspenseQuery({
     ...assignmentQueries.all(assignmentId),
     select: list => {
-      return list.map(data => ({ ...data, status: 'success' }));
+      return list.map(data => ({ ...data, status: data.status || 'success' }));
     },
   });
   const { handleUpload } = useUploadAssignment(assignmentId);

--- a/src/features/assignment/ui/DropZone.tsx
+++ b/src/features/assignment/ui/DropZone.tsx
@@ -1,0 +1,70 @@
+// src/components/DropZone.tsx
+import { ArrowUpTrayIcon } from '@heroicons/react/24/outline';
+import clsx from 'clsx';
+import { useState } from 'react';
+
+const preventDefaults = (fn: (e: React.DragEvent<HTMLDivElement>) => void) => {
+  return (e: React.DragEvent<HTMLDivElement>) => {
+    e.preventDefault();
+    e.stopPropagation();
+    fn(e);
+  };
+};
+
+interface DropZoneProps {
+  onFilesSelected: (files: FileList) => void;
+}
+
+export default function DropZone({ onFilesSelected }: DropZoneProps) {
+  const [isDragging, setIsDragging] = useState<boolean>(false);
+
+  const handleDragEnter = preventDefaults(() => setIsDragging(true));
+  const handleDragLeave = preventDefaults(() => setIsDragging(false));
+  const handleDragOver = preventDefaults(() => {
+    if (!isDragging) setIsDragging(true);
+  });
+  const handleDrop = preventDefaults(e => {
+    setIsDragging(false);
+    onFilesSelected(e.dataTransfer.files);
+  });
+
+  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    if (e.target.files) {
+      onFilesSelected(e.target.files);
+    }
+  };
+
+  return (
+    <div
+      onDragEnter={handleDragEnter}
+      onDragLeave={handleDragLeave}
+      onDragOver={handleDragOver}
+      onDrop={handleDrop}
+      className={clsx(
+        `mt-1 flex justify-center items-center px-6 pt-5 pb-6 border-2 border-dashed rounded-md cursor-pointer relative`,
+        isDragging ? 'border-blue-400 bg-blue-50' : 'border-gray-300'
+      )}
+    >
+      <input
+        id="file-upload"
+        name="file-upload"
+        type="file"
+        multiple
+        onChange={handleFileChange}
+        className="absolute inset-0 w-full h-full opacity-0 cursor-pointer"
+      />
+      <div className="space-y-1 text-center">
+        <ArrowUpTrayIcon className="mx-auto h-12 w-12 text-gray-400" />
+        <div className="flex text-sm text-gray-600">
+          <label
+            htmlFor="file-upload"
+            className="relative font-medium text-blue-600"
+          >
+            <span>파일 선택</span>
+          </label>
+          <p className="pl-1">또는 파일을 드래그하세요.</p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/features/assignment/ui/FileCard.tsx
+++ b/src/features/assignment/ui/FileCard.tsx
@@ -1,5 +1,6 @@
 import { deleteAssignment, type AssignmentFile } from '@/entities/assignment';
 import { StatusDisplay } from '@/features/assignment';
+import { formatFileSize } from '@/shared';
 import { DocumentIcon, XCircleIcon } from '@heroicons/react/24/outline';
 import { useMutation } from '@tanstack/react-query';
 
@@ -27,7 +28,9 @@ export default function FileCard({ assignmentFile }: FileCardProps) {
         <div className="flex-1 pl-5">
           <span>{assignmentFile.fileName}</span>
           <div className="flex gap-2">
-            <p className="text-primary-blue">{assignmentFile.fileSize}</p>
+            <p className="text-primary-blue">
+              {formatFileSize(assignmentFile.fileSize)}
+            </p>
             <StatusDisplay status={assignmentFile.status} />
           </div>
         </div>

--- a/src/features/assignment/ui/FileCard.tsx
+++ b/src/features/assignment/ui/FileCard.tsx
@@ -1,4 +1,5 @@
 import { deleteAssignment, type AssignmentFile } from '@/entities/assignment';
+import { StatusDisplay } from '@/features/assignment';
 import { DocumentIcon, XCircleIcon } from '@heroicons/react/24/outline';
 import { useMutation } from '@tanstack/react-query';
 
@@ -27,7 +28,7 @@ export default function FileCard({ assignmentFile }: FileCardProps) {
           <span>{assignmentFile.fileName}</span>
           <div className="flex gap-2">
             <p className="text-primary-blue">{assignmentFile.fileSize}</p>
-            <p className="text-gray-200">{assignmentFile.status}</p>
+            <StatusDisplay status={assignmentFile.status} />
           </div>
         </div>
         <button

--- a/src/features/assignment/ui/FileCard.tsx
+++ b/src/features/assignment/ui/FileCard.tsx
@@ -1,11 +1,21 @@
-import type { AssignmentFile } from '@/entities/assignment';
+import { deleteAssignment, type AssignmentFile } from '@/entities/assignment';
 import { DocumentIcon, XCircleIcon } from '@heroicons/react/24/outline';
+import { useMutation } from '@tanstack/react-query';
 
 interface FileCardProps {
   assignmentFile: AssignmentFile;
 }
 
 export default function FileCard({ assignmentFile }: FileCardProps) {
+  const { mutate } = useMutation({
+    mutationFn: deleteAssignment,
+  });
+  const handleMutate = () => {
+    if (confirm('정말 삭제하시겠습니까?')) {
+      mutate(assignmentFile.id);
+    }
+  };
+
   return (
     <li
       className="border border-black rounded-lg px-5 py-2.5 my-2"
@@ -17,10 +27,16 @@ export default function FileCard({ assignmentFile }: FileCardProps) {
           <span>{assignmentFile.fileName}</span>
           <div className="flex gap-2">
             <p className="text-primary-blue">{assignmentFile.fileSize}</p>
-            <p className="text-gray-200">업로드 완료</p>
+            <p className="text-gray-200">{assignmentFile.status}</p>
           </div>
         </div>
-        <XCircleIcon className="size-9 text-red-500" />
+        <button
+          type="button"
+          className="p-2 cursor-pointer"
+          onClick={handleMutate}
+        >
+          <XCircleIcon className="size-9 text-red-500" />
+        </button>
       </div>
     </li>
   );

--- a/src/features/assignment/ui/FileCard.tsx
+++ b/src/features/assignment/ui/FileCard.tsx
@@ -1,0 +1,27 @@
+import type { AssignmentFile } from '@/entities/assignment';
+import { DocumentIcon, XCircleIcon } from '@heroicons/react/24/outline';
+
+interface FileCardProps {
+  assignmentFile: AssignmentFile;
+}
+
+export default function FileCard({ assignmentFile }: FileCardProps) {
+  return (
+    <li
+      className="border border-black rounded-lg px-5 py-2.5 my-2"
+      key={assignmentFile.id}
+    >
+      <div className="flex items-center">
+        <DocumentIcon className="size-9" />
+        <div className="flex-1 pl-5">
+          <span>{assignmentFile.fileName}</span>
+          <div className="flex gap-2">
+            <p className="text-primary-blue">{assignmentFile.fileSize}</p>
+            <p className="text-gray-200">업로드 완료</p>
+          </div>
+        </div>
+        <XCircleIcon className="size-9 text-red-500" />
+      </div>
+    </li>
+  );
+}

--- a/src/features/assignment/ui/FileList.tsx
+++ b/src/features/assignment/ui/FileList.tsx
@@ -1,0 +1,17 @@
+import type { AssignmentFile } from '@/entities/assignment';
+import { FileCard } from '@/features/assignment';
+
+interface AssignmentFileListProps {
+  assignmentsFileList: AssignmentFile[];
+}
+export default function FileList({
+  assignmentsFileList,
+}: AssignmentFileListProps) {
+  return (
+    <ul className="overflow-y-auto">
+      {assignmentsFileList.map(assignmentFile => (
+        <FileCard key={assignmentFile.id} assignmentFile={assignmentFile} />
+      ))}
+    </ul>
+  );
+}

--- a/src/features/assignment/ui/FileList.tsx
+++ b/src/features/assignment/ui/FileList.tsx
@@ -7,6 +7,7 @@ interface AssignmentFileListProps {
 export default function FileList({
   assignmentsFileList,
 }: AssignmentFileListProps) {
+  console.log(assignmentsFileList);
   return (
     <ul className="overflow-y-auto">
       {assignmentsFileList.map(assignmentFile => (

--- a/src/features/assignment/ui/FileList.tsx
+++ b/src/features/assignment/ui/FileList.tsx
@@ -7,7 +7,6 @@ interface AssignmentFileListProps {
 export default function FileList({
   assignmentsFileList,
 }: AssignmentFileListProps) {
-  console.log(assignmentsFileList);
   return (
     <ul className="overflow-y-auto">
       {assignmentsFileList.map(assignmentFile => (

--- a/src/features/assignment/ui/FileSubmitForm.tsx
+++ b/src/features/assignment/ui/FileSubmitForm.tsx
@@ -1,18 +1,9 @@
-import { createAssignment } from '@/entities/assignment';
 import { DropZone } from '@/features/assignment';
-import { useMutation } from '@tanstack/react-query';
 
-export default function FileSubmitForm() {
-  const { mutate } = useMutation({
-    mutationFn: createAssignment,
-  });
-
-  const handleUpload = (files: FileList) => {
-    for (const file of files) {
-      mutate(file);
-    }
-  };
-
+interface FileSubmitFormProps {
+  handleUpload: (files: FileList) => void;
+}
+export default function FileSubmitForm({ handleUpload }: FileSubmitFormProps) {
   return (
     <form>
       <div className="mb-6">

--- a/src/features/assignment/ui/FileSubmitForm.tsx
+++ b/src/features/assignment/ui/FileSubmitForm.tsx
@@ -1,6 +1,53 @@
+import { createAssignment } from '@/entities/assignment';
+import { AddFileButton } from '@/features/assignment';
 import { ArrowUpTrayIcon } from '@heroicons/react/24/outline';
-
+import { useMutation } from '@tanstack/react-query';
+import clsx from 'clsx';
+import { useState } from 'react';
+const preventDefaults = (
+  callback: (e: React.DragEvent<HTMLDivElement>) => void
+) => {
+  return (e: React.DragEvent<HTMLDivElement>) => {
+    e.preventDefault();
+    e.stopPropagation();
+    callback(e);
+  };
+};
 export default function FileSubmitForm() {
+  const [isDragging, setIsDragging] = useState<boolean>(false);
+  const { mutate } = useMutation({
+    mutationFn: createAssignment,
+    onSuccess: data => {
+      console.log('업로드 성공:', data);
+    },
+    onError: error => {
+      console.error('업로드 실패:', error);
+      alert('파일 업로드에 실패했습니다.');
+    },
+  });
+
+  const handleDragEnter = preventDefaults(() => {
+    setIsDragging(true);
+  });
+
+  const handleDragLeave = preventDefaults(() => {
+    setIsDragging(false);
+  });
+
+  const handleDragOver = preventDefaults(() => {
+    if (!isDragging) {
+      setIsDragging(true);
+    }
+  });
+
+  const handleDrop = preventDefaults(e => {
+    setIsDragging(false);
+    for (const file of e.dataTransfer.files) {
+      mutate(file);
+    }
+    console.log(e.dataTransfer.files);
+  });
+
   return (
     <form>
       <div className="mb-6">
@@ -8,8 +55,15 @@ export default function FileSubmitForm() {
           파일 업로드
         </label>
         <div
-          className="mt-1 flex justify-center items-center px-6 pt-5 pb-6 border-2 border-gray-300 border-dashed rounded-md
-                           hover:border-blue-400 transition-colors duration-200 cursor-pointer relative"
+          onDragEnter={handleDragEnter}
+          onDragLeave={handleDragLeave}
+          onDragOver={handleDragOver}
+          onDrop={handleDrop}
+          className={clsx(
+            `mt-1 flex justify-center items-center px-6 pt-5 pb-6 border-2  border-dashed rounded-md
+                          cursor-pointer relative`,
+            isDragging ? 'border-blue-200 bg-blue-50' : 'border-gray-300 '
+          )}
         >
           <input
             id="file-upload"
@@ -22,7 +76,7 @@ export default function FileSubmitForm() {
             <div className="flex text-sm text-gray-600">
               <label
                 htmlFor="file-upload"
-                className="relative cursor-pointer bg-white rounded-md font-medium text-blue-600 hover:text-blue-500 focus-within:outline-none  focus-within:ring-blue-500"
+                className="relative  font-medium text-blue-600"
               >
                 <span>파일 선택</span>
               </label>
@@ -32,13 +86,11 @@ export default function FileSubmitForm() {
         </div>
       </div>
       <div className="flex flex-col md:flex-row items-start md:items-center justify-between">
-        <button
-          type="button"
-          className="justify-center py-2 px-4 text-white border-blue-300 border-b-4 shadow-sky-950 shadow- text-sm font-medium rounded-md  bg-primary-blue
-                           hover:bg-secondary-blue  focus:outline-none hover:border-secondary-blue mb-4 md:mb-0"
-        >
-          다운로드
-        </button>
+        <AddFileButton
+          onFilesSelected={file => {
+            console.log(file);
+          }}
+        ></AddFileButton>
         <div className="flex items-center">
           <label
             htmlFor="score"

--- a/src/features/assignment/ui/FileSubmitForm.tsx
+++ b/src/features/assignment/ui/FileSubmitForm.tsx
@@ -5,14 +5,13 @@ import { useMutation } from '@tanstack/react-query';
 export default function FileSubmitForm() {
   const { mutate } = useMutation({
     mutationFn: createAssignment,
-    onSuccess: data => {
-      console.log('업로드 성공:', data);
-    },
-    onError: error => {
-      console.error('업로드 실패:', error);
-      alert('파일 업로드에 실패했습니다.');
-    },
   });
+
+  const handleUpload = (files: FileList) => {
+    for (const file of files) {
+      mutate(file);
+    }
+  };
 
   return (
     <form>
@@ -20,14 +19,7 @@ export default function FileSubmitForm() {
         <label className="block text-sm font-bold text-gray-700 mb-2">
           파일 업로드
         </label>
-        <DropZone
-          onFilesSelected={files => {
-            for (const file of files) {
-              console.log(file);
-              mutate(file);
-            }
-          }}
-        />
+        <DropZone onFilesSelected={handleUpload} />
       </div>
     </form>
   );

--- a/src/features/assignment/ui/FileSubmitForm.tsx
+++ b/src/features/assignment/ui/FileSubmitForm.tsx
@@ -1,6 +1,6 @@
 import { ArrowUpTrayIcon } from '@heroicons/react/24/outline';
 
-export default function AssignmentForm() {
+export default function FileSubmitForm() {
   return (
     <form>
       <div className="mb-6">

--- a/src/features/assignment/ui/FileSubmitForm.tsx
+++ b/src/features/assignment/ui/FileSubmitForm.tsx
@@ -1,20 +1,8 @@
 import { createAssignment } from '@/entities/assignment';
-import { AddFileButton } from '@/features/assignment';
-import { ArrowUpTrayIcon } from '@heroicons/react/24/outline';
+import { DropZone } from '@/features/assignment';
 import { useMutation } from '@tanstack/react-query';
-import clsx from 'clsx';
-import { useState } from 'react';
-const preventDefaults = (
-  callback: (e: React.DragEvent<HTMLDivElement>) => void
-) => {
-  return (e: React.DragEvent<HTMLDivElement>) => {
-    e.preventDefault();
-    e.stopPropagation();
-    callback(e);
-  };
-};
+
 export default function FileSubmitForm() {
-  const [isDragging, setIsDragging] = useState<boolean>(false);
   const { mutate } = useMutation({
     mutationFn: createAssignment,
     onSuccess: data => {
@@ -26,86 +14,20 @@ export default function FileSubmitForm() {
     },
   });
 
-  const handleDragEnter = preventDefaults(() => {
-    setIsDragging(true);
-  });
-
-  const handleDragLeave = preventDefaults(() => {
-    setIsDragging(false);
-  });
-
-  const handleDragOver = preventDefaults(() => {
-    if (!isDragging) {
-      setIsDragging(true);
-    }
-  });
-
-  const handleDrop = preventDefaults(e => {
-    setIsDragging(false);
-    for (const file of e.dataTransfer.files) {
-      mutate(file);
-    }
-    console.log(e.dataTransfer.files);
-  });
-
   return (
     <form>
       <div className="mb-6">
         <label className="block text-sm font-bold text-gray-700 mb-2">
           파일 업로드
         </label>
-        <div
-          onDragEnter={handleDragEnter}
-          onDragLeave={handleDragLeave}
-          onDragOver={handleDragOver}
-          onDrop={handleDrop}
-          className={clsx(
-            `mt-1 flex justify-center items-center px-6 pt-5 pb-6 border-2  border-dashed rounded-md
-                          cursor-pointer relative`,
-            isDragging ? 'border-blue-200 bg-blue-50' : 'border-gray-300 '
-          )}
-        >
-          <input
-            id="file-upload"
-            name="file-upload"
-            type="file"
-            className="absolute inset-0 w-full h-full opacity-0 cursor-pointer"
-          />
-          <div className="space-y-1 text-center">
-            <ArrowUpTrayIcon className="mx-auto h-12 w-12 text-gray-400" />
-            <div className="flex text-sm text-gray-600">
-              <label
-                htmlFor="file-upload"
-                className="relative  font-medium text-blue-600"
-              >
-                <span>파일 선택</span>
-              </label>
-              <p className="pl-1">또는 파일을 드래그하세요.</p>
-            </div>
-          </div>
-        </div>
-      </div>
-      <div className="flex flex-col md:flex-row items-start md:items-center justify-between">
-        <AddFileButton
-          onFilesSelected={file => {
-            console.log(file);
+        <DropZone
+          onFilesSelected={files => {
+            for (const file of files) {
+              console.log(file);
+              mutate(file);
+            }
           }}
-        ></AddFileButton>
-        <div className="flex items-center">
-          <label
-            htmlFor="score"
-            className="block text-sm font-medium text-gray-700 mr-2"
-          >
-            점수
-          </label>
-          <input
-            type="text"
-            name="score"
-            id="score"
-            readOnly
-            className="block w-20 rounded-md border-gray-300 shadow-sm sm:text-sm p-2"
-          />
-        </div>
+        />
       </div>
     </form>
   );

--- a/src/features/assignment/ui/components/StatusDisplay.tsx
+++ b/src/features/assignment/ui/components/StatusDisplay.tsx
@@ -1,0 +1,33 @@
+// FileCard.tsx 파일 상단이나 별도의 파일에 만들어도 좋습니다.
+import {
+  ArrowPathIcon,
+  CheckCircleIcon,
+  ExclamationCircleIcon,
+} from '@heroicons/react/24/outline';
+export default function StatusDisplay({ status }: { status?: string }) {
+  if (status === 'uploading') {
+    return (
+      <div className="flex items-center gap-1 text-sm text-gray-500">
+        <ArrowPathIcon className="size-4 animate-spin" />
+        <span>업로드 중...</span>
+      </div>
+    );
+  }
+
+  if (status === 'error') {
+    return (
+      <div className="flex items-center gap-1 text-sm text-red-500">
+        <ExclamationCircleIcon className="size-4" />
+        <span>업로드 실패</span>
+      </div>
+    );
+  }
+
+  // 'success' 상태 또는 status 값이 없을 때
+  return (
+    <div className="flex items-center gap-1 text-sm text-green-600">
+      <CheckCircleIcon className="size-4" />
+      <span>제출 완료</span>
+    </div>
+  );
+}

--- a/src/features/assignment/ui/components/index.ts
+++ b/src/features/assignment/ui/components/index.ts
@@ -1,1 +1,2 @@
 export { default as AssignmentHeader } from './AssignmentHeader';
+export { default as StatusDisplay } from './StatusDisplay';

--- a/src/features/assignment/ui/index.ts
+++ b/src/features/assignment/ui/index.ts
@@ -1,4 +1,7 @@
 export * from './components';
-export { default as AssignmentForm } from './AssignmentForm';
+export { default as FileSubmitForm } from './FileSubmitForm';
 export { default as CommentList } from './CommentList';
 export { default as CommentForm } from './CommentForm';
+export { default as AssignmentContainer } from './AssignmentContainer';
+export { default as FileList } from './FileList';
+export { default as FileCard } from './FileCard';

--- a/src/features/assignment/ui/index.ts
+++ b/src/features/assignment/ui/index.ts
@@ -5,3 +5,4 @@ export { default as CommentForm } from './CommentForm';
 export { default as AssignmentContainer } from './AssignmentContainer';
 export { default as FileList } from './FileList';
 export { default as FileCard } from './FileCard';
+export { default as AddFileButton } from './AddFileButton';

--- a/src/features/assignment/ui/index.ts
+++ b/src/features/assignment/ui/index.ts
@@ -6,3 +6,4 @@ export { default as AssignmentContainer } from './AssignmentContainer';
 export { default as FileList } from './FileList';
 export { default as FileCard } from './FileCard';
 export { default as AddFileButton } from './AddFileButton';
+export { default as DropZone } from './DropZone';

--- a/src/mocks/assignment.mock.ts
+++ b/src/mocks/assignment.mock.ts
@@ -5,27 +5,29 @@ let ASSIGNMENT_MOCKS = [
     fileName: 'react_basics_guide.txt',
     fileContent:
       '리액트의 기본 개념: 컴포넌트, JSX, Props, State에 대한 문서입니다.',
+    fileSize: 2048,
   },
   {
     id: 'a2',
     fileName: 'msw_setup_manual.md',
     fileContent:
       '# MSW 설정 가이드\n\n1. `npm install msw --save-dev`\n2. `npx msw init public/ --save`\n\n위 명령어를 순서대로 실행하세요.',
+    fileSize: 1024,
   },
   {
     id: 'a3',
     fileName: 'state_management_report.csv',
     fileContent:
       '라이브러리,장점,단점\nRedux,안정적,보일러플레이트 많음\nZustand,간결함,생태계 작음\nRecoil,원자적 상태,아직 불안정',
+    fileSize: 3072,
   },
 ];
 
 export const assignmentHandler = [
-  //특정 강의의 특정 과제 조회
-  http.get('/api/lecture/:lectureId/assignment/:assignmentId', () => {
+  http.get('/api/assignment/:assignmentId', () => {
     return HttpResponse.json({ data: ASSIGNMENT_MOCKS });
   }),
-  http.post('/api/lecture/:lectureId/assignment', async ({ request }) => {
+  http.post('/api/assignment', async ({ request }) => {
     const formData = await request.formData();
     const file = formData.get('file');
     if (!file || !(file instanceof File)) {
@@ -39,31 +41,29 @@ export const assignmentHandler = [
       id: `a${Date.now()}`,
       fileName: file.name,
       fileContent: `(업로드된 파일: ${file.name}, 크기: ${file.size} bytes)`,
+      fileSize: file.size,
     };
 
     ASSIGNMENT_MOCKS.unshift(newAssignment);
 
     return HttpResponse.json(newAssignment, { status: 201 });
   }),
-  http.delete(
-    '/api/lecture/:lectureId/assignment/:assignmentId',
-    ({ params }) => {
-      const { assignmentId } = params;
+  http.delete('/api/assignment/:assignmentId', ({ params }) => {
+    const { assignmentId } = params;
 
-      const originalLength = ASSIGNMENT_MOCKS.length;
+    const originalLength = ASSIGNMENT_MOCKS.length;
 
-      ASSIGNMENT_MOCKS = ASSIGNMENT_MOCKS.filter(
-        assignment => assignment.id !== assignmentId
+    ASSIGNMENT_MOCKS = ASSIGNMENT_MOCKS.filter(
+      assignment => assignment.id !== assignmentId
+    );
+
+    if (ASSIGNMENT_MOCKS.length < originalLength) {
+      return new HttpResponse(null, { status: 204 });
+    } else {
+      return HttpResponse.json(
+        { message: '해당 과제를 찾을 수 없습니다.' },
+        { status: 404 }
       );
-
-      if (ASSIGNMENT_MOCKS.length < originalLength) {
-        return new HttpResponse(null, { status: 204 });
-      } else {
-        return HttpResponse.json(
-          { message: '해당 과제를 찾을 수 없습니다.' },
-          { status: 404 }
-        );
-      }
     }
-  ),
+  }),
 ];

--- a/src/mocks/assignment.mock.ts
+++ b/src/mocks/assignment.mock.ts
@@ -1,27 +1,6 @@
+import type { AssignmentFile } from '@/entities/assignment';
 import { http, HttpResponse } from 'msw';
-let ASSIGNMENT_MOCKS = [
-  {
-    id: 'a1',
-    fileName: 'react_basics_guide.txt',
-    fileContent:
-      '리액트의 기본 개념: 컴포넌트, JSX, Props, State에 대한 문서입니다.',
-    fileSize: 2048,
-  },
-  {
-    id: 'a2',
-    fileName: 'msw_setup_manual.md',
-    fileContent:
-      '# MSW 설정 가이드\n\n1. `npm install msw --save-dev`\n2. `npx msw init public/ --save`\n\n위 명령어를 순서대로 실행하세요.',
-    fileSize: 1024,
-  },
-  {
-    id: 'a3',
-    fileName: 'state_management_report.csv',
-    fileContent:
-      '라이브러리,장점,단점\nRedux,안정적,보일러플레이트 많음\nZustand,간결함,생태계 작음\nRecoil,원자적 상태,아직 불안정',
-    fileSize: 3072,
-  },
-];
+let ASSIGNMENT_MOCKS: AssignmentFile[] = [];
 
 export const assignmentHandler = [
   http.get('/api/assignment/:assignmentId', ({ params }) => {
@@ -33,14 +12,14 @@ export const assignmentHandler = [
     return HttpResponse.json({ data: null });
   }),
   http.post('/api/assignment', () => {
-    // 1. 이 로그가 브라우저 콘솔에 찍히는지 확인합니다.
-    const newAssignment = {
+    const newAssignment: AssignmentFile = {
       id: `a${Date.now()}`,
-      fileName: 'upload-success.png', // 임의의 파일 이름
-      fileSize: 12345, // 임의의 파일 크기
+      fileName: 'upload-success.png',
+      fileContent: '',
+      fileSize: 12345,
     };
+    ASSIGNMENT_MOCKS.push(newAssignment);
 
-    // 프론트엔드가 기대하는 { data: ... } 형식으로 성공 응답을 반환합니다.
     return HttpResponse.json({ data: newAssignment }, { status: 201 });
   }),
   http.delete('/api/assignment/:assignmentId', ({ params }) => {

--- a/src/mocks/assignment.mock.ts
+++ b/src/mocks/assignment.mock.ts
@@ -1,0 +1,69 @@
+import { http, HttpResponse } from 'msw';
+let ASSIGNMENT_MOCKS = [
+  {
+    id: 'a1',
+    fileName: 'react_basics_guide.txt',
+    fileContent:
+      '리액트의 기본 개념: 컴포넌트, JSX, Props, State에 대한 문서입니다.',
+  },
+  {
+    id: 'a2',
+    fileName: 'msw_setup_manual.md',
+    fileContent:
+      '# MSW 설정 가이드\n\n1. `npm install msw --save-dev`\n2. `npx msw init public/ --save`\n\n위 명령어를 순서대로 실행하세요.',
+  },
+  {
+    id: 'a3',
+    fileName: 'state_management_report.csv',
+    fileContent:
+      '라이브러리,장점,단점\nRedux,안정적,보일러플레이트 많음\nZustand,간결함,생태계 작음\nRecoil,원자적 상태,아직 불안정',
+  },
+];
+
+export const assignmentHandler = [
+  //특정 강의의 특정 과제 조회
+  http.get('/api/lecture/:lectureId/assignment/:assignmentId', () => {
+    return HttpResponse.json({ data: ASSIGNMENT_MOCKS });
+  }),
+  http.post('/api/lecture/:lectureId/assignment', async ({ request }) => {
+    const formData = await request.formData();
+    const file = formData.get('file');
+    if (!file || !(file instanceof File)) {
+      return HttpResponse.json(
+        { message: '제목과 파일이 필요합니다.' },
+        { status: 400 }
+      );
+    }
+
+    const newAssignment = {
+      id: `a${Date.now()}`,
+      fileName: file.name,
+      fileContent: `(업로드된 파일: ${file.name}, 크기: ${file.size} bytes)`,
+    };
+
+    ASSIGNMENT_MOCKS.unshift(newAssignment);
+
+    return HttpResponse.json(newAssignment, { status: 201 });
+  }),
+  http.delete(
+    '/api/lecture/:lectureId/assignment/:assignmentId',
+    ({ params }) => {
+      const { assignmentId } = params;
+
+      const originalLength = ASSIGNMENT_MOCKS.length;
+
+      ASSIGNMENT_MOCKS = ASSIGNMENT_MOCKS.filter(
+        assignment => assignment.id !== assignmentId
+      );
+
+      if (ASSIGNMENT_MOCKS.length < originalLength) {
+        return new HttpResponse(null, { status: 204 });
+      } else {
+        return HttpResponse.json(
+          { message: '해당 과제를 찾을 수 없습니다.' },
+          { status: 404 }
+        );
+      }
+    }
+  ),
+];

--- a/src/mocks/assignment.mock.ts
+++ b/src/mocks/assignment.mock.ts
@@ -1,5 +1,5 @@
 import type { AssignmentFile } from '@/entities/assignment';
-import { http, HttpResponse } from 'msw';
+import { delay, http, HttpResponse } from 'msw';
 let ASSIGNMENT_MOCKS: AssignmentFile[] = [];
 
 export const assignmentHandler = [
@@ -11,7 +11,8 @@ export const assignmentHandler = [
 
     return HttpResponse.json({ data: null });
   }),
-  http.post('/api/assignment', () => {
+  http.post('/api/assignment', async () => {
+    await delay(5000);
     const newAssignment: AssignmentFile = {
       id: `a${Date.now()}`,
       fileName: 'upload-success.png',
@@ -28,7 +29,7 @@ export const assignmentHandler = [
     const originalLength = ASSIGNMENT_MOCKS.length;
 
     ASSIGNMENT_MOCKS = ASSIGNMENT_MOCKS.filter(
-      assignment => assignment.id !== assignmentId
+      assignment => assignment.id !== assignmentId,
     );
 
     if (ASSIGNMENT_MOCKS.length < originalLength) {
@@ -36,7 +37,7 @@ export const assignmentHandler = [
     } else {
       return HttpResponse.json(
         { message: '해당 과제를 찾을 수 없습니다.' },
-        { status: 404 }
+        { status: 404 },
       );
     }
   }),

--- a/src/mocks/assignment.mock.ts
+++ b/src/mocks/assignment.mock.ts
@@ -24,8 +24,13 @@ let ASSIGNMENT_MOCKS = [
 ];
 
 export const assignmentHandler = [
-  http.get('/api/assignment/:assignmentId', () => {
-    return HttpResponse.json({ data: ASSIGNMENT_MOCKS });
+  http.get('/api/assignment/:assignmentId', ({ params }) => {
+    const { assignmentId } = params;
+    if (assignmentId === 'l2-a1') {
+      return HttpResponse.json({ data: ASSIGNMENT_MOCKS });
+    }
+
+    return HttpResponse.json({ data: null });
   }),
   http.post('/api/assignment', async ({ request }) => {
     const formData = await request.formData();

--- a/src/mocks/assignment.mock.ts
+++ b/src/mocks/assignment.mock.ts
@@ -32,26 +32,16 @@ export const assignmentHandler = [
 
     return HttpResponse.json({ data: null });
   }),
-  http.post('/api/assignment', async ({ request }) => {
-    const formData = await request.formData();
-    const file = formData.get('file');
-    if (!file || !(file instanceof File)) {
-      return HttpResponse.json(
-        { message: '제목과 파일이 필요합니다.' },
-        { status: 400 }
-      );
-    }
-
+  http.post('/api/assignment', () => {
+    // 1. 이 로그가 브라우저 콘솔에 찍히는지 확인합니다.
     const newAssignment = {
       id: `a${Date.now()}`,
-      fileName: file.name,
-      fileContent: `(업로드된 파일: ${file.name}, 크기: ${file.size} bytes)`,
-      fileSize: file.size,
+      fileName: 'upload-success.png', // 임의의 파일 이름
+      fileSize: 12345, // 임의의 파일 크기
     };
 
-    ASSIGNMENT_MOCKS.unshift(newAssignment);
-
-    return HttpResponse.json(newAssignment, { status: 201 });
+    // 프론트엔드가 기대하는 { data: ... } 형식으로 성공 응답을 반환합니다.
+    return HttpResponse.json({ data: newAssignment }, { status: 201 });
   }),
   http.delete('/api/assignment/:assignmentId', ({ params }) => {
     const { assignmentId } = params;

--- a/src/mocks/auth.mock.ts
+++ b/src/mocks/auth.mock.ts
@@ -4,10 +4,9 @@ const MOCK_ID = 'john';
 const MOCK_PW = 'secret';
 export const authHandlers = [
   http.post<object, { id: string; password: string }>(
-    '/api/login',
+    '/api/user/login',
     async ({ request }) => {
       const { id, password } = await request.json();
-
       if (id === MOCK_ID && password === MOCK_PW) {
         return HttpResponse.json(
           { message: 'Login successful' },
@@ -15,15 +14,15 @@ export const authHandlers = [
             headers: {
               'set-cookie': 'sessionId=abc123; Path=/api;',
             },
-          }
+          },
         );
       }
 
       return HttpResponse.json(
         { message: 'Invalid credentials' },
-        { status: 401 }
+        { status: 401 },
       );
-    }
+    },
   ),
 
   http.get('/api/user', ({ cookies }) => {
@@ -39,7 +38,7 @@ export const authHandlers = [
 
     return HttpResponse.json(
       { data: null, message: 'Unauthorized' },
-      { status: 200 }
+      { status: 200 },
     );
   }),
   http.post<object, { id: string; password: string }>(
@@ -54,15 +53,15 @@ export const authHandlers = [
             headers: {
               'set-cookie': 'sessionId=abc123; Path=/api;',
             },
-          }
+          },
         );
       }
 
       return HttpResponse.json(
         { message: 'Invalid credentials' },
-        { status: 401 }
+        { status: 401 },
       );
-    }
+    },
   ),
   http.post<object, { id: string }>(
     '/api/user/check-id',
@@ -76,11 +75,11 @@ export const authHandlers = [
             headers: {
               'set-cookie': 'sessionId=abc123; Path=/api;',
             },
-          }
+          },
         );
       }
 
       return HttpResponse.json({ status: false }, { status: 200 });
-    }
+    },
   ),
 ];

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -1,3 +1,4 @@
+import { assignmentHandler } from '@/mocks/assignment.mock';
 import { authHandlers } from '@/mocks/auth.mock';
 import { courseHandlers } from '@/mocks/course.mock';
 import { kpiHandlers } from '@/mocks/kpi.mock';
@@ -7,4 +8,5 @@ export const handlers = [
   ...kpiHandlers,
   ...courseHandlers,
   ...lectureHandlers,
+  ...assignmentHandler,
 ];

--- a/src/mocks/lecture.mock.ts
+++ b/src/mocks/lecture.mock.ts
@@ -1,6 +1,6 @@
 import { http, HttpResponse } from 'msw';
 // lectures.mock.ts
-const LECTURE_MOCKS = [
+export const LECTURE_MOCKS = [
   {
     id: 1,
     week: 1,
@@ -9,11 +9,11 @@ const LECTURE_MOCKS = [
     progress: 100,
     itemsByType: {
       videos: [
-        { id: 'v1', title: '강의 1', completed: true },
-        { id: 'v2', title: '강의 2', completed: true },
+        { id: 'l1-v1', title: '강의 1', completed: true },
+        { id: 'l1-v2', title: '강의 2', completed: true },
       ],
-      materials: [{ id: 'm1', title: '자료 1', completed: true }],
-      assignments: [{ id: 'a1', title: '과제 1', completed: true }],
+      materials: [{ id: 'l1-m1', title: '자료 1', completed: true }],
+      assignments: [{ id: 'l1-a1', title: '과제 1', completed: true }],
     },
     stats: { videos: 2, assignments: 1, materials: 1 },
   },
@@ -25,12 +25,12 @@ const LECTURE_MOCKS = [
     progress: 80,
     itemsByType: {
       videos: [
-        { id: 'v1', title: '강의 1', completed: true },
-        { id: 'v2', title: '강의 2', completed: true },
-        { id: 'v3', title: '강의 3', completed: false },
+        { id: 'l2-v1', title: '강의 1', completed: true },
+        { id: 'l2-v2', title: '강의 2', completed: true },
+        { id: 'l2-v3', title: '강의 3', completed: false },
       ],
-      materials: [{ id: 'm1', title: '자료 1', completed: false }],
-      assignments: [{ id: 'a1', title: '과제 1', completed: false }],
+      materials: [{ id: 'l2-m1', title: '자료 1', completed: false }],
+      assignments: [{ id: 'l2-a1', title: '과제 1', completed: false }],
     },
     stats: { videos: 3, assignments: 1, materials: 1 },
   },
@@ -42,14 +42,14 @@ const LECTURE_MOCKS = [
     progress: 60,
     itemsByType: {
       videos: [
-        { id: 'v1', title: '강의 1', completed: true },
-        { id: 'v2', title: '강의 2', completed: false },
+        { id: 'l3-v1', title: '강의 1', completed: true },
+        { id: 'l3-v2', title: '강의 2', completed: false },
       ],
       materials: [
-        { id: 'm1', title: '자료 1', completed: true },
-        { id: 'm2', title: '자료 2', completed: false },
+        { id: 'l3-m1', title: '자료 1', completed: true },
+        { id: 'l3-m2', title: '자료 2', completed: false },
       ],
-      assignments: [{ id: 'a1', title: '과제 1', completed: false }],
+      assignments: [{ id: 'l3-a1', title: '과제 1', completed: false }],
     },
     stats: { videos: 2, assignments: 1, materials: 2 },
   },
@@ -61,12 +61,12 @@ const LECTURE_MOCKS = [
     progress: 40,
     itemsByType: {
       videos: [
-        { id: 'v1', title: '강의 1', completed: true },
-        { id: 'v2', title: '강의 2', completed: false },
-        { id: 'v3', title: '강의 3', completed: false },
+        { id: 'l4-v1', title: '강의 1', completed: true },
+        { id: 'l4-v2', title: '강의 2', completed: false },
+        { id: 'l4-v3', title: '강의 3', completed: false },
       ],
       materials: [],
-      assignments: [{ id: 'a1', title: '과제 1', completed: false }],
+      assignments: [{ id: 'l4-a1', title: '과제 1', completed: false }],
     },
     stats: { videos: 3, assignments: 1, materials: 0 },
   },
@@ -78,10 +78,10 @@ const LECTURE_MOCKS = [
     progress: 20,
     itemsByType: {
       videos: [
-        { id: 'v1', title: '강의 1', completed: true },
-        { id: 'v2', title: '강의 2', completed: false },
+        { id: 'l5-v1', title: '강의 1', completed: true },
+        { id: 'l5-v2', title: '강의 2', completed: false },
       ],
-      materials: [{ id: 'm1', title: '자료 1', completed: false }],
+      materials: [{ id: 'l5-m1', title: '자료 1', completed: false }],
       assignments: [],
     },
     stats: { videos: 2, assignments: 0, materials: 1 },
@@ -94,12 +94,12 @@ const LECTURE_MOCKS = [
     progress: 0,
     itemsByType: {
       videos: [
-        { id: 'v1', title: '강의 1', completed: false },
-        { id: 'v2', title: '강의 2', completed: false },
-        { id: 'v3', title: '강의 3', completed: false },
+        { id: 'l6-v1', title: '강의 1', completed: false },
+        { id: 'l6-v2', title: '강의 2', completed: false },
+        { id: 'l6-v3', title: '강의 3', completed: false },
       ],
-      materials: [{ id: 'm1', title: '자료 1', completed: false }],
-      assignments: [{ id: 'a1', title: '과제 1', completed: false }],
+      materials: [{ id: 'l6-m1', title: '자료 1', completed: false }],
+      assignments: [{ id: 'l6-a1', title: '과제 1', completed: false }],
     },
     stats: { videos: 3, assignments: 1, materials: 1 },
   },
@@ -111,11 +111,11 @@ const LECTURE_MOCKS = [
     progress: 0,
     itemsByType: {
       videos: [
-        { id: 'v1', title: '강의 1', completed: false },
-        { id: 'v2', title: '강의 2', completed: false },
+        { id: 'l7-v1', title: '강의 1', completed: false },
+        { id: 'l7-v2', title: '강의 2', completed: false },
       ],
-      materials: [{ id: 'm1', title: '자료 1', completed: false }],
-      assignments: [{ id: 'a1', title: '과제 1', completed: false }],
+      materials: [{ id: 'l7-m1', title: '자료 1', completed: false }],
+      assignments: [{ id: 'l7-a1', title: '과제 1', completed: false }],
     },
     stats: { videos: 2, assignments: 1, materials: 1 },
   },
@@ -127,20 +127,19 @@ const LECTURE_MOCKS = [
     progress: 0,
     itemsByType: {
       videos: [
-        { id: 'v1', title: '강의 1', completed: false },
-        { id: 'v2', title: '강의 2', completed: false },
-        { id: 'v3', title: '강의 3', completed: false },
+        { id: 'l8-v1', title: '강의 1', completed: false },
+        { id: 'l8-v2', title: '강의 2', completed: false },
+        { id: 'l8-v3', title: '강의 3', completed: false },
       ],
       materials: [
-        { id: 'm1', title: '자료 1', completed: false },
-        { id: 'm2', title: '자료 2', completed: false },
+        { id: 'l8-m1', title: '자료 1', completed: false },
+        { id: 'l8-m2', title: '자료 2', completed: false },
       ],
-      assignments: [{ id: 'a1', title: '과제 1', completed: false }],
+      assignments: [{ id: 'l8-a1', title: '과제 1', completed: false }],
     },
     stats: { videos: 3, assignments: 1, materials: 2 },
   },
 ];
-
 export const lectureHandlers = [
   http.get('/api/lecture/:id', async ({ cookies }) => {
     if (cookies.sessionId === 'abc123') {

--- a/src/pages/Assignment.tsx
+++ b/src/pages/Assignment.tsx
@@ -1,8 +1,8 @@
 import {
   CommentList,
-  AssignmentForm,
   AssignmentHeader,
   CommentForm,
+  AssignmentContainer,
 } from '@/features/assignment';
 
 export default function Assignment() {
@@ -10,19 +10,7 @@ export default function Assignment() {
     <main className="min-h-screen bg-gray-100 p-8" aria-labelledby="page-title">
       <div className="max-w-4xl mx-auto bg-white shadow-lg rounded-lg">
         <AssignmentHeader />
-        <section
-          className="p-6 md:p-8 mb-4"
-          aria-labelledby="submission-heading"
-        >
-          <h2
-            id="submission-heading"
-            className="text-xl font-semibold text-gray-800 mb-6"
-          >
-            과제 제출
-          </h2>
-          <AssignmentForm />
-        </section>
-
+        <AssignmentContainer />
         <section className="p-6 md:p-8" aria-labelledby="comments-heading">
           <h2
             id="comments-heading"

--- a/src/shared/index.ts
+++ b/src/shared/index.ts
@@ -1,3 +1,4 @@
 export * from './ui';
 export * from './api';
 export * from './queryKey';
+export * from './libs';

--- a/src/shared/libs/formatFileSize.ts
+++ b/src/shared/libs/formatFileSize.ts
@@ -1,0 +1,9 @@
+export const formatFileSize = (bytes: number): string => {
+  if (bytes < 1024) return `${bytes} B`;
+  const kb = bytes / 1024;
+  if (kb < 1024) return `${kb.toFixed(1)} KB`;
+  const mb = kb / 1024;
+  if (mb < 1024) return `${mb.toFixed(1)} MB`;
+  const gb = mb / 1024;
+  return `${gb.toFixed(1)} GB`;
+};

--- a/src/shared/libs/index.ts
+++ b/src/shared/libs/index.ts
@@ -1,0 +1,1 @@
+export * from './formatFileSize';


### PR DESCRIPTION
## 🔗 관련 이슈
#25 
<!-- 이 PR과 관련된 이슈 번호를 적어주세요. 예: #123 -->

## 📝작업 내용
<img width="803" height="703" alt="image" src="https://github.com/user-attachments/assets/76b04626-5ea1-4939-b6b5-04ac30f99c47" />

### 과제 제출기능을 추가했습니다.
드래그앤드롭을통해 파일을 받는 `DropZone` 컴포넌트를 추가했습니다. 추후 공용사용시 `shared`로 내려도 될것같습니다.

### `useUploadAssignment`
여러개의 과제를 제출할때 각각의 Promise를 추적하기 위해 mutateAsync를 사용해서 상태를 추적하는 로직을 추가했습니다.

과제 업로드를 UI로 제공하고싶은데 이런식으로 안하면 각각 상태를 추적하기가 힘들어서 어쩔수없이 약간 좀 복잡해지긴 했습니다 ㅎㅎ;


<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->

## 🔍 변경 사항

- [ ] 변경 사항 1
- [ ] 변경 사항 2
- [ ] 변경 사항 3

## 💬리뷰 요구사항 (선택사항)
